### PR TITLE
fix: status page logic

### DIFF
--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -24,38 +24,36 @@
 	<div class="m-8">
 		{#each data.degrees as degree, i}
 			{#if degree.teachings != null}
-        {#if i > 0}
-          <hr class="my-8 border-primary" />
-        {/if}
-        <h2 class="text-center text-2xl">{degree.name}</h2>
-				{#each
-          [...Array(MAX_YEARS_FOR_DEGREE).keys()].map((i) => i + 1).concat([0])
-          as year}
-          {@const teachings = teachingsFilter(degree, year)}
-          {#if teachings.length > 0}
-            <h3 class="text-center text-xl font-bold my-4">{year || "Senza anno"}</h3>
-            <div class="grid grid-cols-4 gap-4">
-              {#each teachings as teaching}
-                <div>
-                  <h4 class="font-bold">{teaching}</h4>
-                  {#if data.activeTeachings[i].includes(teaching)}
-                    <div class="flex gap-2">
-                      {#each WORKFLOW_NAMES as workflow}
-                        {@const url = data.teachings.get(teaching)?.url}
-                        {#if url != null}
-                          {@const href = WORKFLOW_URL(url, workflow)}
-                          {@const src = `${href}/badge.svg`}
-                          <a {href}>
-                            <img {src} alt="Not found" />
-                          </a>
-                        {/if}
-                      {/each}
-                    </div>
-                  {/if}
-                </div>
-              {/each}
-            </div>
-          {/if}
+				{#if i > 0}
+					<hr class="my-8 border-primary" />
+				{/if}
+				<h2 class="text-center text-2xl">{degree.name}</h2>
+				{#each [...Array(MAX_YEARS_FOR_DEGREE).keys()].map((i) => i + 1).concat([0]) as year}
+					{@const teachings = teachingsFilter(degree, year)}
+					{#if teachings.length > 0}
+						<h3 class="text-center text-xl font-bold my-4">{year || 'Senza anno'}</h3>
+						<div class="grid grid-cols-4 gap-4">
+							{#each teachings as teaching}
+								<div>
+									<h4 class="font-bold">{teaching}</h4>
+									{#if data.activeTeachings[i].includes(teaching)}
+										<div class="flex gap-2">
+											{#each WORKFLOW_NAMES as workflow}
+												{@const url = data.teachings.get(teaching)?.url}
+												{#if url != null}
+													{@const href = WORKFLOW_URL(url, workflow)}
+													{@const src = `${href}/badge.svg`}
+													<a {href}>
+														<img {src} alt="Not found" />
+													</a>
+												{/if}
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
 				{/each}
 			{/if}
 		{/each}

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -23,34 +23,39 @@
 	</nav>
 	<div class="m-8">
 		{#each data.degrees as degree, i}
-			{#if i > 0}
-				<hr class="my-8 border-primary" />
-			{/if}
-			<h2 class="text-center text-2xl">{degree.name}</h2>
 			{#if degree.teachings != null}
-				{#each [...Array(MAX_YEARS_FOR_DEGREE).keys()].map((i) => i + 1) as year}
-					<h3 class="text-center text-xl font-bold my-4">{year}</h3>
-					<div class="grid grid-cols-4 gap-4">
-						{#each teachingsFilter(degree, year) as teaching}
-							<div>
-								<h4 class="font-bold">{teaching}</h4>
-								{#if data.activeTeachings[i].includes(teaching)}
-									<div class="flex gap-2">
-										{#each WORKFLOW_NAMES as workflow}
-											{@const url = data.teachings.get(teaching)?.url}
-											{#if url != null}
-												{@const href = WORKFLOW_URL(url, workflow)}
-												{@const src = `${href}/badge.svg`}
-												<a {href}>
-													<img {src} alt="Not found" />
-												</a>
-											{/if}
-										{/each}
-									</div>
-								{/if}
-							</div>
-						{/each}
-					</div>
+        {#if i > 0}
+          <hr class="my-8 border-primary" />
+        {/if}
+        <h2 class="text-center text-2xl">{degree.name}</h2>
+				{#each
+          [...Array(MAX_YEARS_FOR_DEGREE).keys()].map((i) => i + 1).concat([0])
+          as year}
+          {@const teachings = teachingsFilter(degree, year)}
+          {#if teachings.length > 0}
+            <h3 class="text-center text-xl font-bold my-4">{year || "Senza anno"}</h3>
+            <div class="grid grid-cols-4 gap-4">
+              {#each teachings as teaching}
+                <div>
+                  <h4 class="font-bold">{teaching}</h4>
+                  {#if data.activeTeachings[i].includes(teaching)}
+                    <div class="flex gap-2">
+                      {#each WORKFLOW_NAMES as workflow}
+                        {@const url = data.teachings.get(teaching)?.url}
+                        {#if url != null}
+                          {@const href = WORKFLOW_URL(url, workflow)}
+                          {@const src = `${href}/badge.svg`}
+                          <a {href}>
+                            <img {src} alt="Not found" />
+                          </a>
+                        {/if}
+                      {/each}
+                    </div>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
 				{/each}
 			{/if}
 		{/each}


### PR DESCRIPTION
~I am a frontend dev now uwu~

Fixes several things wrong with the status page's template:
- the header of degress with no courses is not displayed any more;
- a special section for "yearless" courses is now available for each degree where it applies (closes #349)
- years with 0 courses are not displayed any more.