### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cartabinaria/dynamik/security/code-scanning/1](https://github.com/cartabinaria/dynamik/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the current workflow, it appears that only read access to repository contents is necessary. Therefore, we will add the following permissions block at the root level of the workflow:

```yaml
permissions:
  contents: read
```

This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unauthorized modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
